### PR TITLE
Make easier for users to point to their geonetwork application

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ format usable in GeoNetwork opensource.
 
 A script is provided to convert GEMET thesaurus https://www.eionet.europa.eu/gemet/
 
+Before running any script create `GEONETWORK_HOME` environment variable pointing the Geonetwork deployment directory: 
 
-Use the following to generate a GEMET SKOS file with many languages:
+```
+export GEONETWORK_HOME=../dev/web/target/geonetwork
+```
+
+Then use the following to generate a GEMET SKOS file with many languages:
+
 ```
 ./gemet-to-simpleskos.sh en fr de nl it
 ```
-
-Note: Update GEONETWORK_HOME variable before running any scripts.
 
 
 ## Thesaurus

--- a/gemet-to-simpleskos.sh
+++ b/gemet-to-simpleskos.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
-export GEONETWORK_HOME=../dev/web/target/geonetwork
-export CLASSPATH=.:$GEONETWORK_HOME/WEB-INF/lib/saxon-9.1.0.8b-patch.jar
+# export GEONETWORK_HOME=../dev/web/target/geonetwork
+
+export SAXON_PATH=$GEONETWORK_HOME/WEB-INF/lib/saxon-9.1.0.8b-patch.jar
+
+if [ ! -f "$SAXON_PATH" ]; then
+  echo "Saxon could not be found in $SAXON_PATH. Check you have set GEONETWORK_HOME env variable correctly"
+  exit 1
+fi
+
+exit 1
+
+export CLASSPATH=.:$SAXON_PATH
 
 if [ $1 ]
 then


### PR DESCRIPTION
I've spent some time wondering why this script didn't work for me and then I realized the `GEONETWORK_HOME` was set inside `gemet-to-simpleskos.sh` to a path different to my geonetwork installation. 

If a new user executes the suggested command `./gemet-to-simpleskos.sh en fr de nl it` without updating the value of `GEONETWORK_HOME` inside `gemet-to-simpleskos.sh` it will fail with a confusing error:

```bash
Creating thesaurus ...
Error: Could not find or load main class net.sf.saxon.Transform
```

This happens because the CLASSPATH for the java call should contain `$GEONETWORK_HOME/WEB-INF/lib/saxon-9.1.0.8b-patch.jar` and the `GEONETWORK_HOME` is set inside `gemet-to-simpleskos.sh` to a default path. If geonetwork is not present at that path the script will fail.

A better approach is make the user set the `GEONETWORK_HOME` variable before calling the script.

I also added a check to warn the user if the script could not locate the saxon jar. In this case it will print an error message and exit with an error code.